### PR TITLE
Fix favicon sizes value in manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "192x192",
+      "sizes": "64x64",
       "type": "image/png"
     }
   ],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "64x64",
+      "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/png"
     }
   ],


### PR DESCRIPTION
See this PR for more info https://github.com/facebook/create-react-app/pull/3287 this is causing a warning in the console. Changing the value to "64x64" clears the warning.